### PR TITLE
change navigation naming from "sell&rent" to "sell&rent out"

### DIFF
--- a/frontend/src/app/navigation/navigation.component.html
+++ b/frontend/src/app/navigation/navigation.component.html
@@ -32,7 +32,7 @@
     routerLink="/products/manage"
   >
     <mat-icon>gavel</mat-icon>
-    <span>Sell & Lend</span>
+    <span>Sell & Rent Out</span>
   </button>
   <button
     *ngIf="userService.isAdmin"


### PR DESCRIPTION
closes #66 