### PR TITLE
Improve error handling

### DIFF
--- a/backend/src/middlewares/checkAuth.ts
+++ b/backend/src/middlewares/checkAuth.ts
@@ -20,12 +20,12 @@ export function verifyToken(req: IAuthRequest, res: Response, next: any) {
     const token = req.headers.authorization.split(' ')[1];
     const decoded = jwt.verify(token, secret);
     if (decoded == null) {
-      res.status(403).send({ message: 'Unauthorized. Please Log-in first.' });
+      res.status(403).send({ message: 'Unauthorized. Please Log-in first.', type: 'NotLoggedIn' });
     }
     // adds the field "tokenPayload" to the request enabling following functions to use data from the token
     req.user = decoded as IUserToken;
     next();
   } catch (err) {
-    res.status(403).send({ message: 'Unauthorized. Please Log-in first.' });
+    res.status(403).send({ message: 'Unauthorized. Please Log-in first.' , type: 'NotLoggedIn' });
   }
 }

--- a/backend/src/middlewares/checkAuth.ts
+++ b/backend/src/middlewares/checkAuth.ts
@@ -20,12 +20,12 @@ export function verifyToken(req: IAuthRequest, res: Response, next: any) {
     const token = req.headers.authorization.split(' ')[1];
     const decoded = jwt.verify(token, secret);
     if (decoded == null) {
-      res.status(403).send({ message: 'Unauthorized' });
+      res.status(403).send({ message: 'Unauthorized. Please Log-in first.' });
     }
     // adds the field "tokenPayload" to the request enabling following functions to use data from the token
     req.user = decoded as IUserToken;
     next();
   } catch (err) {
-    res.status(403).send({ message: 'Unauthorized' });
+    res.status(403).send({ message: 'Unauthorized. Please Log-in first.' });
   }
 }

--- a/backend/src/middlewares/checkAuth.ts
+++ b/backend/src/middlewares/checkAuth.ts
@@ -20,12 +20,12 @@ export function verifyToken(req: IAuthRequest, res: Response, next: any) {
     const token = req.headers.authorization.split(' ')[1];
     const decoded = jwt.verify(token, secret);
     if (decoded == null) {
-      res.status(403).send({ message: 'Unauthorized. Please Log-in first.', type: 'NotLoggedIn' });
+      res.status(403).send({ message: 'Unauthorized. Please Log-in first.', name: 'NotLoggedIn' });
     }
     // adds the field "tokenPayload" to the request enabling following functions to use data from the token
     req.user = decoded as IUserToken;
     next();
   } catch (err) {
-    res.status(403).send({ message: 'Unauthorized. Please Log-in first.' , type: 'NotLoggedIn' });
+    res.status(403).send(err);
   }
 }

--- a/backend/src/middlewares/checkIsAdmin.ts
+++ b/backend/src/middlewares/checkIsAdmin.ts
@@ -8,6 +8,6 @@ export function checkIsAdmin(req: IAuthRequest, res: Response, next: NextFunctio
             next();
         }
     } else {
-        res.status(403).send({ message: 'Unauthorized. You have to be admin to perform this action.' });
+        res.status(403).send({ message: 'Unauthorized. You have to be admin to perform this action.', type: 'NotAdmin'});
     }
 }

--- a/backend/src/middlewares/checkIsAdmin.ts
+++ b/backend/src/middlewares/checkIsAdmin.ts
@@ -8,6 +8,6 @@ export function checkIsAdmin(req: IAuthRequest, res: Response, next: NextFunctio
             next();
         }
     } else {
-        res.status(403).send({ message: 'Unauthorized' });
+        res.status(403).send({ message: 'Unauthorized. You have to be admin to perform this action.' });
     }
 }

--- a/backend/src/middlewares/checkIsAdmin.ts
+++ b/backend/src/middlewares/checkIsAdmin.ts
@@ -8,6 +8,6 @@ export function checkIsAdmin(req: IAuthRequest, res: Response, next: NextFunctio
             next();
         }
     } else {
-        res.status(403).send({ message: 'Unauthorized. You have to be admin to perform this action.', type: 'NotAdmin'});
+        res.status(403).send({ message: 'Unauthorized. You have to be admin to perform this action.', name: 'NotAdmin'});
     }
 }

--- a/backend/src/middlewares/checkProductAuthorization.ts
+++ b/backend/src/middlewares/checkProductAuthorization.ts
@@ -19,7 +19,7 @@ export async function checkProductAuthorization(req: IAuthRequest, res: Response
             if (product) {
                 next();
             } else {
-                res.status(403).send({ message: 'Unauthorized. This product doesn\'t belong to your account.', type: 'NotYourProduct' });
+                res.status(403).send({ message: 'Unauthorized. This product doesn\'t belong to your account.', name: 'NotYourProduct' });
             }
         }
     } catch (err) {

--- a/backend/src/middlewares/checkProductAuthorization.ts
+++ b/backend/src/middlewares/checkProductAuthorization.ts
@@ -19,7 +19,7 @@ export async function checkProductAuthorization(req: IAuthRequest, res: Response
             if (product) {
                 next();
             } else {
-                res.status(403).send({ message: 'Unauthorized' });
+                res.status(403).send({ message: 'Unauthorized. This product doesn\'t belong to your account.' });
             }
         }
     } catch (err) {

--- a/backend/src/middlewares/checkProductAuthorization.ts
+++ b/backend/src/middlewares/checkProductAuthorization.ts
@@ -19,7 +19,7 @@ export async function checkProductAuthorization(req: IAuthRequest, res: Response
             if (product) {
                 next();
             } else {
-                res.status(403).send({ message: 'Unauthorized. This product doesn\'t belong to your account.' });
+                res.status(403).send({ message: 'Unauthorized. This product doesn\'t belong to your account.', type: 'NotYourProduct' });
             }
         }
     } catch (err) {

--- a/backend/src/middlewares/checkProductAuthorizationInverted.ts
+++ b/backend/src/middlewares/checkProductAuthorizationInverted.ts
@@ -14,7 +14,7 @@ export async function checkProductAuthorizationInverted(req: IAuthRequest, res: 
             }
         });
         if (product) {
-            res.status(403).send({ message: 'You can\'t buy your own product!', type: 'BuyOwnProduct' });
+            res.status(403).send({ message: 'You can\'t buy your own product!', name: 'BuyOwnProduct' });
         } else {
             next();
         }

--- a/backend/src/middlewares/checkProductAuthorizationInverted.ts
+++ b/backend/src/middlewares/checkProductAuthorizationInverted.ts
@@ -14,7 +14,7 @@ export async function checkProductAuthorizationInverted(req: IAuthRequest, res: 
             }
         });
         if (product) {
-            res.status(403).send({ message: 'You can\'t buy your own product!' });
+            res.status(403).send({ message: 'You can\'t buy your own product!', type: 'BuyOwnProduct' });
         } else {
             next();
         }

--- a/frontend/src/app/helper/http-error.interceptor.ts
+++ b/frontend/src/app/helper/http-error.interceptor.ts
@@ -9,10 +9,11 @@ import {
 import { Observable } from 'rxjs';
 import { tap, finalize } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 
 @Injectable()
 export class HttpErrorInterceptor implements HttpInterceptor {
-  constructor(private snackBar: MatSnackBar) {}
+  constructor(private snackBar: MatSnackBar, private router: Router) {}
 
   intercept(
     request: HttpRequest<unknown>,
@@ -21,12 +22,35 @@ export class HttpErrorInterceptor implements HttpInterceptor {
     let error;
     return next.handle(request).pipe(
       tap(null, (err: HttpErrorResponse) => (error = err)),
-      finalize(() =>
-        error
-          ? this.snackBar.open(error.message, 'close', {
+      finalize(() => {
+        if (error) {
+          switch (error.type) {
+            case 'BuyOwnProduct' : {
+
+            }
+            case 'NotYourProduct' : {
+
+            }
+            case 'NotAdmin' : {
+
+            }
+            case 'NotLoggedIn' : {
+              this.snackBar.open(error.message, 'Log in', {
+                duration: 5000,
+              })
+              .onAction().subscribe(
+                () => {
+                  this.router.navigate(['login'])
+                }
+              );
+            }
+            default : this.snackBar.open(error.message, 'close', {
               duration: 5000,
             })
-          : null
+          }
+        }
+        else { null }
+      }
       )
     );
   }


### PR DESCRIPTION
Resolves #150, resolves #162 

Works: 
Error handling of errors propagating through/thrown by the middlewares of the backend. A snackbar is shown to inform the user. the snackbar action is also implemented appropriate.
also, when the token expires, the user gets logged out in the frontend and has the possibility to directly navigate to log in screen via the snackbar action.

Doesn't work: 
Errors thrown by for example the image service are not specifically handled. the standard error message is shown (For example: "Http failure response for http://localhost:3000/api/images/9: 500 Internal Server Error") in a snack bar with a 'close' action.