### PR TITLE
Return rent product

### DIFF
--- a/backend/src/controllers/products.controller.ts
+++ b/backend/src/controllers/products.controller.ts
@@ -63,6 +63,20 @@ productController.put(
   }
 );
 
+productController.put(
+  '/:productId/return',
+  verifyToken,
+  async (req: Request<{productId: string}>, res: Response, next: NextFunction) => {
+    try {
+      const productId = req.params.productId;
+      const returnedProduct = await productService.return(productId);
+      res.send(returnedProduct);
+    } catch (err) {
+      return next(err);
+    }
+  }
+);
+
 
 
 productController.get(

--- a/backend/src/models/product.model.ts
+++ b/backend/src/models/product.model.ts
@@ -90,7 +90,7 @@ export class Product extends Model<ProductAttributes, ProductCreationAttributes>
                 type: DataTypes.STRING,
                 defaultValue: 'pending',
                 validate: {
-                    isIn: [['pending', 'approved', 'rejected', 'inactive', 'sold', 'rent']],
+                    isIn: [['pending', 'approved', 'rejected', 'returned', 'inactive', 'sold', 'rent']],
                 }
             },
             rentalDays: {

--- a/backend/src/services/product.service.ts
+++ b/backend/src/services/product.service.ts
@@ -47,6 +47,12 @@ export class ProductService {
     return product.save();
   }
 
+  public async return(productId: string): Promise<Product> {
+    const product = await Product.findByPk(productId);
+    product.status = 'returned';
+    return product.save();
+  }
+
   public async delete(productId: string) {
     const product = await Product.findByPk(productId);
     if (['approved', 'pending'].includes(product.status)) {

--- a/frontend/src/app/products/manage/manage.component.html
+++ b/frontend/src/app/products/manage/manage.component.html
@@ -28,11 +28,23 @@
     [product]="product"
   >
     <div class="action-buttons">
-      <button color="primary" mat-flat-button (click)="goToEdit(product)">
+      <button color="primary" 
+        mat-flat-button 
+        (click)="goToEdit(product)"
+        matTooltip="edit product">
         EDIT
       </button>
-      <button mat-mini-fab color="primary" (click)="delete(product)">
+      <button mat-mini-fab color="primary" 
+        (click)="delete(product)"
+        matTooltip="delete product">
         <mat-icon>delete</mat-icon>
+      </button>
+      <button 
+        *ngIf="product.purchaseType === 'rent' && product.status === 'rent'" 
+        mat-mini-fab color="primary" 
+        matTooltip="mark product as returned"
+        (click)="return(product)">
+        <mat-icon>compare_arrows</mat-icon>
       </button>
     </div>
   </app-product-item>

--- a/frontend/src/app/products/manage/manage.component.ts
+++ b/frontend/src/app/products/manage/manage.component.ts
@@ -4,6 +4,7 @@ import { ProductsService, IProduct } from '../products.service';
 import { UserService } from 'src/app/user/user.service';
 import { MatDialog } from '@angular/material/dialog';
 import { DeleteComponent } from '../delete/delete.component';
+import { ReturnComponent } from '../return/return.component';
 
 @Component({
   selector: 'app-products-manage',
@@ -47,6 +48,20 @@ export class ManageComponent implements OnInit {
       });
   }
 
+  return(product: IProduct): void {
+    this.dialog
+      .open(ReturnComponent)
+      .afterClosed()
+      .subscribe((result) => {
+        if (result) {
+          this.productService
+            .return(product.id)
+            .subscribe(() => this.reloadProducts());
+        }
+      });
+  }
+
+
   reloadProducts(): void {
     this.productService.getMyProducts().subscribe((prods) => {
       this.products = prods;
@@ -77,7 +92,7 @@ export class ManageComponent implements OnInit {
   filterLentProducts(status: string): void {
     if (status === 'rent') {
       this.filteredProducts = this.products.filter((product) =>
-        ['rent'].includes(product.status)
+        ['rent', 'returned'].includes(product.status)
       );
     } else {
       this.filteredProducts = [];

--- a/frontend/src/app/products/products.module.ts
+++ b/frontend/src/app/products/products.module.ts
@@ -41,6 +41,8 @@ import { DetailsComponent } from './details/details.component';
 import { ApproveComponent } from './approve/approve.component';
 import { AnswerFormComponent } from './question/answer-form/answer-form.component';
 import { QuestionAnswersComponent } from './details/question-answers/question-answers.component';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { ReturnComponent } from './return/return.component';
 
 @NgModule({
   declarations: [
@@ -64,6 +66,7 @@ import { QuestionAnswersComponent } from './details/question-answers/question-an
     ApproveComponent,
     AnswerFormComponent,
     QuestionAnswersComponent,
+    ReturnComponent,
   ],
   imports: [
     CommonModule,
@@ -85,7 +88,8 @@ import { QuestionAnswersComponent } from './details/question-answers/question-an
     Ng2SearchPipeModule,
     MatBadgeModule,
     MatCheckboxModule,
-    MatExpansionModule
+    MatExpansionModule,
+    MatTooltipModule,
   ],
   exports: [
     BrowseComponent

--- a/frontend/src/app/products/products.service.ts
+++ b/frontend/src/app/products/products.service.ts
@@ -46,6 +46,10 @@ export class ProductsService {
     return this.http.put<IProduct>(this.url + `/${productId}/approve`, {});
   }
 
+  return(productId: number): Observable<IProduct> {
+    return this.http.put<IProduct>(this.url + `/${productId}/return`, {});
+  }
+
   reject(productId: number): Observable<IProduct> {
     return this.http.put<IProduct>(this.url + `/${productId}/reject`, {});
   }

--- a/frontend/src/app/products/return/return.component.html
+++ b/frontend/src/app/products/return/return.component.html
@@ -1,0 +1,9 @@
+<h1 mat-dialog-title>Return Product?</h1>
+<div mat-dialog-content>
+    Has the user returned the Product to you?<br>
+</div>
+<div mat-dialog-actions>
+  <button mat-button mat-dialog-close>Cancel</button>
+  <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
+  <button mat-flat-button color="primary" [mat-dialog-close]="true">YES</button>
+</div>

--- a/frontend/src/app/products/return/return.component.spec.ts
+++ b/frontend/src/app/products/return/return.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReturnComponent } from './return.component';
+
+describe('ReturnComponent', () => {
+  let component: ReturnComponent;
+  let fixture: ComponentFixture<ReturnComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ReturnComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ReturnComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/products/return/return.component.ts
+++ b/frontend/src/app/products/return/return.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-return',
+  templateUrl: './return.component.html',
+  styleUrls: ['./return.component.css']
+})
+export class ReturnComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
resolves #137 

**What works:**
Product that has been rent, may be returnet and it's status us update to returned. 

**What it doesen't do**
Create a new product with the same attributes
I would anyway suggest, that we should not automatically create this new product. 
Instead we can implement a functionality, for the user to: reactivate sold, and returned goods (services stay on the platform anyway) I'll create a new issue for this. 
